### PR TITLE
Fix brand name/logo redirecting to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Non-exhaustive TODO-list:
  - [ ] add https
  - [ ] add posts from previous website
  - [ ] add a comments engine
+ - [ ] fix baseUrl and "iScsc" sidebar not redirecting
  - [ ] print a `lastUpdate` or `updated` date param on posts
  - [ ] show posts which `draft` param is `true` in dev mode (if possible)
  - [ ] check when building (with builder target) that git submodule is updated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   builder:
     image: klakegg/hugo:0.111.3
-    command: --verbose
+    command: --verbose --baseUrl="https://iscsc.fr"
     environment:
       - HUGO_DESTINATION=/build/blog
       # For maximum backward compatibility with Hugo modules:


### PR DESCRIPTION
because the `baseUrl` object wasn't set HUGO couldn't rightly set up the redirecting to home page, it has been tested on production