### PR TITLE
Add author to articles info and make author a taxonomy

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -103,4 +103,5 @@ pluralizelisttitles = false   # removes the automatically appended "s" on sideba
 [taxonomies]
     series = 'series'
     tags = 'tags'
+    author = 'author'
 


### PR DESCRIPTION
closes #16 

needs https://github.com/ctmbl/poison/pull/1

following https://github.com/lukeorth/poison/issues/170 on original poison repo