### PR TITLE
Fix `/author/<author name>` title case

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   builder:
     image: floryn90/hugo:0.123.7
-    command: --verbose --baseURL="https://iscsc.fr" --buildFuture
+    command: --logLevel info --baseURL="https://iscsc.fr" --buildFuture
     environment:
       - HUGO_DESTINATION=/build/blog
       # For maximum backward compatibility with Hugo modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   builder:
     image: floryn90/hugo:0.123.7
-    command: --verbose --baseUrl="https://iscsc.fr" --buildFuture
+    command: --verbose --baseURL="https://iscsc.fr" --buildFuture
     environment:
       - HUGO_DESTINATION=/build/blog
       # For maximum backward compatibility with Hugo modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   builder:
-    image: klakegg/hugo:0.111.3
+    image: floryn90/hugo:0.111.3
     command: --verbose --baseUrl="https://iscsc.fr" --buildFuture
     environment:
       - HUGO_DESTINATION=/build/blog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   builder:
-    image: floryn90/hugo:0.111.3
+    image: floryn90/hugo:0.123.7
     command: --verbose --baseUrl="https://iscsc.fr" --buildFuture
     environment:
       - HUGO_DESTINATION=/build/blog

--- a/src/config.toml
+++ b/src/config.toml
@@ -9,6 +9,7 @@ enableEmoji = true
 # copy paste from https://themes.gohugo.io/themes/poison/#example-config :
 paginate = 10
 pluralizelisttitles = false   # removes the automatically appended "s" on sidebar entries
+capitalizelisttitles = false  # respect list title case; ex with author: ctmbl stays ctmbl not Ctmbl
 
 # NOTE: If using Disqus as commenting engine, uncomment and configure this line
 # disqusShortname = "yourDisqusShortname"


### PR DESCRIPTION
Before HUGO 0.123.x all list titles were "titled" meaning get a capital letter to the first word (at least) 

hugo 0.123.x introduced `capitalizelisttitles` config option https://github.com/gohugoio/hugo/pull/12121 


This PR thus:
- change HUGO image repo to an up-to-date one: [floryn90's fork](https://github.com/floryn90/docker-hugo) of [klakegg](https://github.com/klakegg/docker-hugo) 
- update to hugo 0.123.7
- add this option to config.toml
- fix some deprecated hugo flags in dokcer compose