### PR TITLE
Remove deprecated `version` in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   builder:
     image: floryn90/hugo:0.123.7


### PR DESCRIPTION
```
± docker compose up -d blog
WARN[0000] /opt/blog.iscsc.fr/docker-compose.yml: `version` is obsolete
```
justifies it

https://github.com/docker/compose/issues/11628#issuecomment-2000072567 and https://github.com/docker/compose/issues/11628#issuecomment-2075664290
explain it