### PR TITLE
Update deprecated http2 nginx conf syntax

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,8 +30,9 @@ http {
 
 
     server {
-        listen 443 default_server ssl http2;
-        listen [::]:443 ssl http2;
+        listen 443 default_server ssl;
+        listen [::]:443 ssl;
+        http2 on;
 
         server_name www.iscsc.fr iscsc.fr;
 


### PR DESCRIPTION
Justified by:
```
± docker logs blogiscscfr-blog-1 | tail
2024/04/26 22:21:23 [warn] 8#8: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/nginx.conf
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/nginx.conf
```
Also:
- https://github.com/nginxinc/kubernetes-ingress/issues/4237
- https://www.nginx.com/blog/nginx-plus-r30-released/#Important-Changes-in-Behavior-