### PR TITLE
Add deploy to `dev.iscsc.fr` workflow

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,0 +1,41 @@
+name: Build and deploy a PR on dev.iscsc.fr
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # Build job
+  build-and-deploy-dev:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repo AND ITS SUBMODULES
+      - name: 🛒 Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      # Build the static website with the provided docker-compose rules, overriding environment variables to build to /build/blog/dev
+      # Note: /!\ we do not override HUGO_ENV or HUGO_ENVIRONMENT, this is done on purpose to avoid triggering themes' behavior which
+      # are not intended for production and could present security risks
+      - name: 🛠️ Build with HUGO
+        run: |
+          docker compose -e HUGO_DESTINATION=/build/blog/dev up builder --exit-code-from builder
+
+      # Create the SSH key file and fill the known_hosts to avoid a prompt from ssh (1st time connecting to remote host)
+      - name: 🔐 Create Key File
+        run: |
+          mkdir ~/.ssh
+          touch ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+      - name: 🔐 Load Host Keys
+        run: |
+          echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+      - name: 🔑 Populate Key
+        run: |
+          echo "${{ secrets.PRIVATE_SSH_KEY }}" > ~/.ssh/id_rsa
+
+      # Upload the build to the remote server location: the volume shared by the nginx container serving http requests
+      - name: 🚀 Upload
+        run: |
+          rsync --archive --stats --verbose --delete ./build/blog/dev/* ${{ secrets.CI_USER_NAME }}@iscsc.fr:${{ secrets.REPO_PATH_ON_REMOTE }}/build/blog/dev

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: 💉 Inject Development Banner
+        run: |
+          cat ./development_banner.html >> ./src/themes/poison/layouts/partials/sidebar/sidebar.html
+
       # Build the static website with the provided docker-compose rules, overriding environment variables to build to /build/blog/dev
       # Note: /!\ we do not override HUGO_ENV or HUGO_ENVIRONMENT, this is done on purpose to avoid triggering themes' behavior which
       # are not intended for production and could present security risks

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -4,10 +4,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Allows
+  pull_request:
+
 jobs:
   # Build job
   build-and-deploy-dev:
     runs-on: ubuntu-latest
+    # Force to respect the 'dev-deployment' environment rules, in our case 1 maintainer approval
+    environment: deployment-dev
     steps:
       # Checkout repo AND ITS SUBMODULES
       - name: 🛒 Checkout

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -25,7 +25,7 @@ jobs:
       # are not intended for production and could present security risks
       - name: 🛠️ Build with HUGO
         run: |
-          docker compose run -v ./build/blog/dev:/build/blog:rw builder --logLevel info --baseURL="https://dev.iscsc.fr" --buildFuture
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml run builder
 
       # Create the SSH key file and fill the known_hosts to avoid a prompt from ssh (1st time connecting to remote host)
       - name: 🔐 Create Key File

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -20,7 +20,7 @@ jobs:
       # are not intended for production and could present security risks
       - name: 🛠️ Build with HUGO
         run: |
-          docker compose -e HUGO_DESTINATION=/build/blog/dev up builder --exit-code-from builder
+          docker compose run -v ./build/blog/dev:/build/blog:rw builder --logLevel info --baseURL="https://dev.iscsc.fr" --buildFuture
 
       # Create the SSH key file and fill the known_hosts to avoid a prompt from ssh (1st time connecting to remote host)
       - name: 🔐 Create Key File

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -4,7 +4,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Allows
+  # Trigger the workflow on every pull request, but because of the environment (later defined)
+  # it will require manual approval to run
   pull_request:
 
 jobs:
@@ -24,9 +25,7 @@ jobs:
         run: |
           cat ./development_banner.html >> ./src/themes/poison/layouts/partials/sidebar/sidebar.html
 
-      # Build the static website with the provided docker-compose rules, overriding environment variables to build to /build/blog/dev
-      # Note: /!\ we do not override HUGO_ENV or HUGO_ENVIRONMENT, this is done on purpose to avoid triggering themes' behavior which
-      # are not intended for production and could present security risks
+      # Build the static website with the provided docker-compose rules, overriding some elements, see docker-compose.dev.yml
       - name: 🛠️ Build with HUGO
         run: |
           docker compose -f docker-compose.yml -f docker-compose.dev.yml run builder

--- a/development_banner.html
+++ b/development_banner.html
@@ -1,4 +1,3 @@
 <div style="background-color:red; color: white; font-size: 2rem; text-align: center; position: fixed; width: 100%; margin-bottom: 50rem;">
     THIS IS A DEVELOPMENT WEBSITE, please go to <a href="https://iscsc.fr" style="font-weight: bold; color:darkslategrey;">https://iscsc.fr</a>
   </div>
-  

--- a/development_banner.html
+++ b/development_banner.html
@@ -1,0 +1,4 @@
+<div style="background-color:red; color: white; font-size: 2rem; text-align: center; position: fixed; width: 100%; margin-bottom: 50rem;">
+    THIS IS A DEVELOPMENT WEBSITE, please go to <a href="https://iscsc.fr" style="font-weight: bold; color:darkslategrey;">https://iscsc.fr</a>
+  </div>
+  

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   builder:
     command: --logLevel info --baseURL="https://dev.iscsc.fr" --buildFuture

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  builder:
+    command: --logLevel info --baseURL="https://dev.iscsc.fr" --buildFuture
+    volumes:
+      # The container is mode-agnostique: it always builds in /build/blog
+      # the volume shared on the host side determines where it should go
+      - ./build/blog/dev:/build/blog:rw

--- a/src/content/posts/fake-new-article.md
+++ b/src/content/posts/fake-new-article.md
@@ -1,8 +1,0 @@
----
-title: "Fake new article"
-date: 2024-05-08T15:04:11+0200
-draft: false
-tags: ["fake"]
----
-
-Fake new article

--- a/src/content/posts/fake-new-article.md
+++ b/src/content/posts/fake-new-article.md
@@ -1,0 +1,8 @@
+---
+title: "Fake new article"
+date: 2024-05-08T15:04:11+0200
+draft: false
+tags: ["fake"]
+---
+
+Fake new article


### PR DESCRIPTION
_completes #53 , see https://github.com/iScsc/blog.iscsc.fr/pull/53#issuecomment-2118290000 to understand_

see https://dev.iscsc.fr/

- [x] create a workflow to deploy a PR to this endpoint
- [x] make the workflow need a maintainer approval (to avoid deployment on EVERY pull request but on-demand)  _see https://github.com/iScsc/blog.iscsc.fr/pull/53#issuecomment-2118018664_
- [x] update/add GH secrets to take into account the new build artifacts hierarchy
- [x] carefully check the build folders consistency across host, containers, documentation and GH workflow
- [x] artificially modify the dev.iscsc.fr webpage to disclaim about its in-devlopment content and give the PR info/commit
- [ ] ~~reate a recurrent workflow that will delete dev.iscsc.fr content and replace it by a default "empty" webpage~~
- [x] BUG: use run and not up with docker cvompose to use -e --> fixed [b154a02](https://github.com/iScsc/blog.iscsc.fr/pull/61/commits/b154a02adceaf2fe72e3651ec52c823bf5853f53)
- [x] BUG: must overwrite --baseURL to dev.iscsc.fr !! --> fixed [b154a02](https://github.com/iScsc/blog.iscsc.fr/pull/61/commits/b154a02adceaf2fe72e3651ec52c823bf5853f53)