### PR TITLE
Update deprecated Actions version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -60,7 +60,7 @@ jobs:
     # If for any reason you want to trigger this step on your fork remove the following line,
     # trigger manually or open an issue https://github.com/iScsc/blog.iscsc.fr/issues,
     # we'll find a better way to skip this step.
-    if: ${{ (github.event_name == 'push' && ! github.event.repository.fork) || github.event_name == 'workflow_dispatch' }}
+    # if: ${{ (github.event_name == 'push' && ! github.event.repository.fork) || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🛠️ Setup build directory
@@ -88,7 +88,7 @@ jobs:
       # Upload the build to the remote server location: the volume shared by the nginx container serving http requests
       - name: 🚀 Upload
         run: |
-          rsync --archive --stats --verbose --delete ./build/blog/prod/* ${{ secrets.CI_USER_NAME }}@iscsc.fr:${{ secrets.REPO_PATH_ON_REMOTE }}/build/blog/prod
+          ls -l ./build/blog/prod
 
       - name: ⏬ Remote git pull
         run: |
@@ -97,8 +97,8 @@ jobs:
   # Finally notify of the new article (if any) on the iScsc discord server
   # action jitterbit/get-changed-files@v1 doesn't support 'workflow_dispatch' events: https://github.com/jitterbit/get-changed-files/issues/38
   notify:
-    needs: [deploy]
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    # needs: [deploy]
+    # if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       # Checkout repo, no need to checkout submodule
@@ -125,7 +125,7 @@ jobs:
           echo "${{ steps.files.outputs.modified }}"
           echo "Added+Modified:"
           echo "${{ steps.files.outputs.added_modified }}"
-      - name: 📨 Notify on Discord
-        run: |
-          python3 -m pip install requests PyYAML
-          python3 ./scripts/new_article.py ${{ steps.files.outputs.added }}
+      # - name: 📨 Notify on Discord
+      #   run: |
+      #     python3 -m pip install requests PyYAML
+      #     python3 ./scripts/new_article.py ${{ steps.files.outputs.added }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -107,7 +107,7 @@ jobs:
 
       # Get the list of added, changed, removed, and renamed files
       - name: 📑 Get changed files
-        uses: jitterbit/get-changed-files@v1
+        uses: masesgroup/retrieve-changed-files@v3
         id: files
         with:
           format: space-delimited

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Checkout repo AND ITS SUBMODULES
       - name: 🛒 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -38,7 +38,7 @@ jobs:
 
       # Upload build artifacts for deployment or download
       - name: 🚀 Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: prod-build
           path: ./build/blog/prod
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir -p build/blog/prod
       - name: 📥 Download build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: prod-build
           path: build/blog/prod
@@ -103,7 +103,7 @@ jobs:
     steps:
       # Checkout repo, no need to checkout submodule
       - name: 🛒 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Get the list of added, changed, removed, and renamed files
       - name: 📑 Get changed files

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -60,7 +60,7 @@ jobs:
     # If for any reason you want to trigger this step on your fork remove the following line,
     # trigger manually or open an issue https://github.com/iScsc/blog.iscsc.fr/issues,
     # we'll find a better way to skip this step.
-    # if: ${{ (github.event_name == 'push' && ! github.event.repository.fork) || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event_name == 'push' && ! github.event.repository.fork) || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🛠️ Setup build directory
@@ -88,7 +88,7 @@ jobs:
       # Upload the build to the remote server location: the volume shared by the nginx container serving http requests
       - name: 🚀 Upload
         run: |
-          ls -l ./build/blog/prod
+          rsync --archive --stats --verbose --delete ./build/blog/prod/* ${{ secrets.CI_USER_NAME }}@iscsc.fr:${{ secrets.REPO_PATH_ON_REMOTE }}/build/blog/prod
 
       - name: ⏬ Remote git pull
         run: |
@@ -97,8 +97,8 @@ jobs:
   # Finally notify of the new article (if any) on the iScsc discord server
   # action jitterbit/get-changed-files@v1 doesn't support 'workflow_dispatch' events: https://github.com/jitterbit/get-changed-files/issues/38
   notify:
-    # needs: [deploy]
-    # if: ${{ github.event_name != 'workflow_dispatch' }}
+    needs: [deploy]
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       # Checkout repo, no need to checkout submodule
@@ -125,7 +125,7 @@ jobs:
           echo "${{ steps.files.outputs.modified }}"
           echo "Added+Modified:"
           echo "${{ steps.files.outputs.added_modified }}"
-      # - name: 📨 Notify on Discord
-      #   run: |
-      #     python3 -m pip install requests PyYAML
-      #     python3 ./scripts/new_article.py ${{ steps.files.outputs.added }}
+      - name: 📨 Notify on Discord
+        run: |
+          python3 -m pip install requests PyYAML
+          python3 ./scripts/new_article.py ${{ steps.files.outputs.added }}

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Checkout repo AND ITS SUBMODULES
       - name: 🛒 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Checkout repo
       - name: 🛒 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install pytest
       - name: 🛠️ Install pytest


### PR DESCRIPTION
Node.js 16 has reached end of life, thus Actions using it are [scheduled for deprecation](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
It concerns [download-artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#actionsdownload-artifact), [upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact) and [checkout](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4) 

However https://github.com/jitterbit/get-changed-files which I use [in the build_and_deploy.yml workflow](https://github.com/iScsc/blog.iscsc.fr/blob/eadb7b159001082bcad97b33a7f69312b0a9ed19/.github/workflows/build_and_deploy.yml#L110) is [not maintained anymore](https://github.com/jitterbit/get-changed-files/issues/65) a [fork exists](https://github.com/jitterbit/get-changed-files/issues/65#issuecomment-1472016848) (https://github.com/masesgroup/retrieve-changed-files?tab=readme-ov-file#retrieve-all-changed-files) so I'll use it
